### PR TITLE
WebGLRenderer: only account for pixel ratio when applying scissor, vi…

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -462,7 +462,16 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		state.viewport( _currentViewport.copy( _viewport ).multiplyScalar( _pixelRatio ).floor() );
+		_currentViewport.copy( _viewport );
+
+		// pixel ratio only applies to the canvas
+		if ( _currentRenderTarget === null ) {
+
+			_currentViewport.multiplyScalar( _pixelRatio );
+
+		}
+
+		state.viewport( _currentViewport.floor() );
 
 	};
 
@@ -484,7 +493,16 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ).floor() );
+		_currentScissor.copy( _scissor );
+
+		// pixel ratio only applies to the canvas
+		if ( _currentRenderTarget === null ) {
+
+			_currentScissor.multiplyScalar( _pixelRatio );
+
+		}
+
+		state.scissor( _currentScissor.floor() );
 
 	};
 


### PR DESCRIPTION
…ewport to canvas

Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
